### PR TITLE
fix: corrigido funcao system_create_user alterado parametro -crypt po…

### DIFF
--- a/lib/_system.sh
+++ b/lib/_system.sh
@@ -15,7 +15,7 @@ system_create_user() {
   sleep 2
 
   sudo su - root <<EOF
-  useradd -m -p $(openssl passwd -crypt ${mysql_root_password}) -s /bin/bash -G sudo deploy
+  useradd -m -p $(openssl passwd -5 ${mysql_root_password}) -s /bin/bash -G sudo deploy
   usermod -aG sudo deploy
 EOF
 
@@ -281,8 +281,11 @@ system_node_install() {
   sleep 2
 
   sudo su - root <<EOF
-  curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
-  apt-get install -y nodejs
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/nodesource-archive-keyring.gpg
+  echo "deb [signed-by=/usr/share/keyrings/nodesource-archive-keyring.gpg] https://deb.nodesource.com/node $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+  echo "deb-src [signed-by=/usr/share/keyrings/nodesource-archive-keyring.gpg] https://deb.nodesource.com/node $(lsb_release -cs) main" | sudo tee -a /etc/apt/sources.list.d/nodesource.list
+  sudo apt update && sudo apt install -y nodejs
+
   sleep 2
   npm install -g npm@latest
   sleep 2


### PR DESCRIPTION
Na funcao system_create_user o parametro -crypt nao existe no openssl e estava causando erro para add user , foi alterado para -5 que representa cryptografica SHA-256

Na funcao system_node_install foi atualizado a maneira de instalar o node uma vez que o script  https://deb.nodesource.com/setup_16.x esta deprecad